### PR TITLE
Upgrading critical versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM adoptopenjdk/openjdk11
+FROM eclipse-temurin:17-jre-noble
 RUN mkdir /app
-COPY target/xyz-tile-cache-0.4.0.jar /app/xyz-tile-cache.jar
+COPY target/xyz-tile-cache-0.5.0.jar /app/xyz-tile-cache.jar
 WORKDIR /app
 EXPOSE 8383
 CMD ["java", "-jar", "/app/xyz-tile-cache.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:17-jre-noble
 RUN mkdir /app
-COPY target/xyz-tile-cache-0.5.0.jar /app/xyz-tile-cache.jar
+COPY target/xyz-tile-cache-0.6.0.jar /app/xyz-tile-cache.jar
 WORKDIR /app
 EXPOSE 8383
 CMD ["java", "-jar", "/app/xyz-tile-cache.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -5,14 +5,14 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.5.9</version>
+		<version>3.3.9</version>
 	</parent>
 	<groupId>org.lockard</groupId>
 	<artifactId>xyz-tile-cache</artifactId>
 	<version>0.5.0</version>
 	<name>xyz-tile-cache</name>
 	<properties>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -43,9 +43,9 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
-				<groupId>com.coveo</groupId>
+				<groupId>com.spotify.fmt</groupId>
 				<artifactId>fmt-maven-plugin</artifactId>
-				<version>2.10</version>
+				<version>2.24</version>
 				<executions>
 					<execution>
 						<phase>validate</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>org.lockard</groupId>
 	<artifactId>xyz-tile-cache</artifactId>
-	<version>0.5.0</version>
+	<version>0.6.0</version>
 	<name>xyz-tile-cache</name>
 	<properties>
 		<java.version>17</java.version>

--- a/src/main/java/org/lockard/xyztilecache/XyzTileCacheApplication.java
+++ b/src/main/java/org/lockard/xyztilecache/XyzTileCacheApplication.java
@@ -20,8 +20,17 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.event.EventListener;
-import org.springframework.http.*;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication


### PR DESCRIPTION
This upgrades the following versions:
- Upgrades Spring from version 2.5.9 to 3.3.9 to fix critical version findings. 
- Upgrades Java 11 to Java 17 to be able to upgrade Spring to v3.
    - Updates Dockerfile base image to `eclipse-temurin:17-jre-noble` to be compatible with Java 17.